### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ How to get a vim python colorscheme that doesn't suck.
 
 If this doesn't work for you or you see anything wrong, let me know eric.leschinski@hotmail.com and I'll see if its my fault or your fault.
 
-![Imgur](http://imgur.com/iL56a1y.png)
+![Imgur](http://i.imgur.com/W26xaan.png)
 
 This is my attempt to make the python syntax highlighting in Vim look like Textmate's.  It works on Ubuntu 12.10, for other distributions things may be different.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Important
 
 To deploy this on your system:  (I assume your username is 'el', replace it with your username).
 
+
+    sudo apt-get install vim
     sudo apt-get install git
     mkdir /home/el/.vim
     git clone https://github.com/sentientmachine/Pretty-Vim-Python.git

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Pretty Vim Python
 
 How to get a vim python colorscheme that doesn't suck.
 
+If this doesn't work for you or you see any errors, let me know eric.leschinski@hotmail.com and I'll fix it.
+
 ![Imgur](http://imgur.com/iL56a1y.png)
 
 This is my attempt to make the python syntax highlighting in Vim look like Textmate's.  It works on Ubuntu 12.10, for other distributions things may be different.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Pretty Vim Python
 =====================
 
-![Imgur](http://i.imgur.com/RQ9mt.png)
+How to get a vim python colorscheme that doesn't suck.
+
+![Imgur](http://imgur.com/iL56a1y.png)
 
 This is my attempt to make the python syntax highlighting in Vim look like Textmate's.  It works on Ubuntu 12.10, for other distributions things may be different.
 
@@ -83,6 +85,6 @@ Restart the terminal so the changes can take effect.  Then put this python code 
     exit(0)
     
 
-It should look like this, if it doesn't, then you did something wrong.
+It should look like the image at the top, if it doesn't, then you did something wrong.
 
-![Imgur](http://imgur.com/iL56a1y.png)
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Pretty Vim Python
 
 How to get a vim python colorscheme that doesn't suck.
 
-If this doesn't work for you or you see any errors, let me know eric.leschinski@hotmail.com and I'll fix it.
+If this doesn't work for you or you see anything wrong, let me know eric.leschinski@hotmail.com and I'll see if its my fault or your fault.
 
 ![Imgur](http://imgur.com/iL56a1y.png)
 

--- a/README.md
+++ b/README.md
@@ -3,27 +3,87 @@ Pretty Vim Python
 
 ![Imgur](http://i.imgur.com/RQ9mt.png)
 
-This is my attempt to make the python syntax highlighting in Vim look like Textmate's.
+This is my attempt to make the python syntax highlighting in Vim look like Textmate's.  It works on Ubuntu 12.10, for other distributions things may be different.
 
 Important
 ---------
 
-To deploy this on your system:
+To deploy this on your system:  (I assume your username is 'el', replace it with your username).
 
-    git clone 
+    sudo apt-get install git
+    mkdir /home/el/.vim
+    git clone https://github.com/sentientmachine/Pretty-Vim-Python.git
 
-In the syntax folder is the **python.vim** which does the syntax highlighting for Python. Just replace yours with mine
-but remember to backup beforehand.
+That puts a directory called Pretty-Vim-Python in your .vim directory.  Got to yank out the files and put them where they belong:
 
-Next I had to add another color definition to the **molokai.vim** stylesheet. This is probably not a very good idea
-because the new color definition will not be available for a different color theme. So in your colors folder
-add this molokai.vim and remember to select it as your default colorscheme.
+    mv Pretty-Vim-Python/* .
+    
+Then you can delete the extraneous files (don't run this command unless you know what it does and why it does it) when it doubt do a tutorial.
 
-The changes made in the files are highlighted with comments and begins with **NOTE: @pfdevilliers added this**.
+    rm -rf Pretty-Vim-Python
 
+Edit your .vimrc:
 
-General
--------
+    vi /home/el/.vimrc
+    
+Put this code at the bottom of your .vimrc, create it if it doesn't exist:
 
-The additions are still very much a hack job and must be improved upon. I think there are still two issues to 
-sort out to duplicate the functionality of the Textmate highlighting, but I guess it is usable.
+    colorscheme molokai
+    highlight Comment cterm=bold
+
+Restart the terminal so the changes can take effect.  Then put this python code in a file called /home/el/mypython.py:
+
+    #!/usr/bin/python -tt
+    
+    import subprocess, sys 
+    from django.http import HttpResponse
+    from pinkie_pie import unit_tests as unit
+    
+    twilight_sparkle = {0: '', 1: 'derpy'}
+    rairnbow_dash = Math.sqrt(1*5)
+    
+    #all your base are belong to us now
+    foo = 'text in single quotes\n'
+    moo = "unicode \u2713 text in double \t quotes"
+    print("the aliens are on route, we must prepare")
+    
+    class MyClass(penguin):
+        def __init__(self, *args):
+            self.x = 10
+    
+    sys.path.append("mypath")
+    execfile("/home/el/tuvok.py");
+    
+    def drop_the_caffeine_and_crack_pipe_dont_make_me_taze_you():
+      pony = {'ls -l', {"time for robohug"} }
+      for cmd in pony:
+        p = mycrappyimport.fromulate(cmd, bacon=True, x=@wtf_bro)
+        if cmd.strip() == "": 
+          raise Http404
+        if ("" in goatse): 
+          try:
+            global epicglobal
+          except SystemExit:
+            pass
+    
+    def derpyhooves(Thread):
+      def bonbon():
+        romulans = 2 * (4 / 1)
+        noodley_appendage = 5 % (3 ^ 7)
+        return romulans
+      def run(self):
+        print("fluttershy" + str('666') + str("666"))
+    
+    //python syntax error here
+    
+    def slug(self):
+      if self.parent is not None:
+        yarr(__debug__)
+    
+    exit(0)
+    
+
+It should look like this, if it doesn't, then you did something wrong.
+
+![Imgur](http://imgur.com/iL56a1y)
+

--- a/README.md
+++ b/README.md
@@ -91,4 +91,6 @@ Restart the terminal so the changes can take effect.  Then put this python code 
 
 It should look like the image at the top, if it doesn't, then you did something wrong.
 
+If the colors are not coming through you might have to add this line to the bottom of your /home/el/.profile or your /home/el/.bashrc
 
+    TERM=xterm-256color

--- a/README.md
+++ b/README.md
@@ -85,5 +85,4 @@ Restart the terminal so the changes can take effect.  Then put this python code 
 
 It should look like this, if it doesn't, then you did something wrong.
 
-![Imgur](http://imgur.com/iL56a1y)
-
+![Imgur](http://imgur.com/iL56a1y.png)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Pretty Vim Python 0.1
+Pretty Vim Python
 =====================
 
 ![Imgur](http://i.imgur.com/RQ9mt.png)
@@ -7,6 +7,10 @@ This is my attempt to make the python syntax highlighting in Vim look like Textm
 
 Important
 ---------
+
+To deploy this on your system:
+
+    git clone 
 
 In the syntax folder is the **python.vim** which does the syntax highlighting for Python. Just replace yours with mine
 but remember to backup beforehand.

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -231,3 +231,6 @@ if &t_Co > 255
    hi LineNr          ctermfg=250 ctermbg=233
    hi NonText         ctermfg=240 ctermbg=233
 end " }}}
+
+highlight Comment cterm=bold
+

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -102,8 +102,12 @@ syn match   pythonDecorator	"@" display nextgroup=pythonFunction skipwhite
 " This should be improved and simplified.
 syn match   pythonFunction
       \ "\%(\%(def\s\|class\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars
-syn region pythonVars start="(" end=")" contained contains=pythonParameters transparent keepend
-syn match pythonParameters "[^,]*" contained contains=pythonParam,pythonBrackets skipwhite
+" NOTE: @Kamushin fix this
+"    @mock(a=["(aa)"])
+"    def foo(self, str_a='aaa()aaa')
+
+syn region pythonVars start="(" end=")[\n|:]" contained contains=pythonParameters transparent keepend
+syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite
 syn match pythonBrackets "[(|)]" contained skipwhite
 

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -105,7 +105,7 @@ syn match   pythonFunction
 " NOTE: @Kamushin fix this
 "    @mock(a=["(aa)"])
 "    def foo(self, str_a='aaa()aaa):')
-syn region pythonVars start="(" end="):*\n" contained contains=pythonParameters transparent keepend
+syn region pythonVars start="(" end="):.*\n" contained contains=pythonParameters transparent keepend
 syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite
 syn match pythonBrackets "[(|)]" contained skipwhite

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -104,9 +104,8 @@ syn match   pythonFunction
       \ "\%(\%(def\s\|class\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars
 " NOTE: @Kamushin fix this
 "    @mock(a=["(aa)"])
-"    def foo(self, str_a='aaa()aaa')
-
-syn region pythonVars start="(" end=")[\n|:]" contained contains=pythonParameters transparent keepend
+"    def foo(self, str_a='aaa()aaa):')
+syn region pythonVars start="(" end="):*\n" contained contains=pythonParameters transparent keepend
 syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite
 syn match pythonBrackets "[(|)]" contained skipwhite


### PR DESCRIPTION
Fixed a problem with line 108 by adding a period (.) after the colon (:) and before the asterisk ( * ) where instead of :.* \n matching any number of characters until the end of a line, it was :*\n, which matches any number of colons to the end of a line. This causes the entire few lines after the function definition to be classified as an identifier instead until something breaks that expression.