### PR TITLE
Add annotation support to Vim syntax file

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -102,9 +102,14 @@ syn match   pythonDecorator	"@" display nextgroup=pythonFunction skipwhite
 " This should be improved and simplified.
 syn match   pythonFunction
       \ "\%(\%(def\s\|class\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars
-syn region pythonVars start="(" end=")" contained contains=pythonParameters transparent keepend
-syn match pythonParameters "[^,]*" contained contains=pythonParam,pythonBrackets skipwhite
+" NOTE: @Kamushin fix this
+"    @mock(a=["(aa)"])
+"    def foo(self, str_a='aaa()aaa):')
+syn region pythonVars start="(" end=")\ze.*:*\n" contained contains=pythonParameters,pythonOutputAnnotation transparent keepend
+syn match pythonOutputAnnotation "\(\zs\s*->.*\)\=" contained
+syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets,pythonInputAnnotation skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite
+syn match pythonInputAnnotation ":[^,:=]*" contained contains=pythonBuiltin
 syn match pythonBrackets "[(|)]" contained skipwhite
 
 " NOTE: @pfdevilliers added this
@@ -315,6 +320,9 @@ if version >= 508 || !exists("did_python_syn_inits")
   HiLink pythonParam Normal
   HiLink pythonBrackets Normal
   HiLink pythonClassParameters InheritUnderlined
+  HiLink pythonOutputAnnotation String
+  HiLink pythonInputAnnotation  String
+
 
   if !exists("python_no_number_highlight")
     HiLink pythonNumber		Number

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -102,14 +102,19 @@ syn match   pythonDecorator	"@" display nextgroup=pythonFunction skipwhite
 " This should be improved and simplified.
 syn match   pythonFunction
       \ "\%(\%(def\s\|class\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars
-" NOTE: @Kamushin fix this
+" NOTE: @Kamushin fix this, then @jorgelespinoza extended this
 "    @mock(a=["(aa)"])
 "    def foo(self, str_a='aaa()aaa):')
 syn region pythonVars start="(" end="\(\(["'].*["'].*\)*$\)*)\ze\(\s*->.*\)\=:\n" contained contains=pythonParameters,pythonOutputAnnotation transparent keepend
+
+" NOTE: @jorgelespinoza added this
+" With the previous line extended and the next two lines added, this syntax file supports annotations
+" and parametes using multiple lines in a function definition. 
+syn match pythonInputAnnotation ":[^,:=]*" contained contains=pythonBuiltin
 syn match pythonOutputAnnotation "\(\zs\s*->.*\)\=" contained
+
 syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets,pythonInputAnnotation skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite
-syn match pythonInputAnnotation ":[^,:=]*" contained contains=pythonBuiltin
 syn match pythonBrackets "[(|)]" contained skipwhite
 
 " NOTE: @pfdevilliers added this

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -105,7 +105,7 @@ syn match   pythonFunction
 " NOTE: @Kamushin fix this
 "    @mock(a=["(aa)"])
 "    def foo(self, str_a='aaa()aaa):')
-syn region pythonVars start="(" end=")\ze.*:*\n" contained contains=pythonParameters,pythonOutputAnnotation transparent keepend
+syn region pythonVars start="(" end="\((.*).*\)*)\ze.*:*\n" contained contains=pythonParameters,pythonOutputAnnotation transparent keepend
 syn match pythonOutputAnnotation "\(\zs\s*->.*\)\=" contained
 syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets,pythonInputAnnotation skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -105,7 +105,7 @@ syn match   pythonFunction
 " NOTE: @Kamushin fix this
 "    @mock(a=["(aa)"])
 "    def foo(self, str_a='aaa()aaa):')
-syn region pythonVars start="(" end="\((.*).*\)*)\ze.*:*\n" contained contains=pythonParameters,pythonOutputAnnotation transparent keepend
+syn region pythonVars start="(" end="\(\(["'].*["'].*\)*$\)*)\ze\(\s*->.*\)\=:\n" contained contains=pythonParameters,pythonOutputAnnotation transparent keepend
 syn match pythonOutputAnnotation "\(\zs\s*->.*\)\=" contained
 syn match pythonParameters "[^,:]*" contained contains=pythonParam,pythonBrackets,pythonInputAnnotation skipwhite
 syn match pythonParam "=[^,]*" contained contains=pythonExtraOperator,pythonBuiltin,pythonConstant,pythonStatement,pythonNumber,pythonString skipwhite


### PR DESCRIPTION
Annotation support needs to be added due to code like this:

```python
def repeat_phrases(phrase1: str, phrase2: str, n: int = 5) -> str: 
    """Repeat two phrases n times.""" 
    phrases = '\n'.join([phrase1, phrase2, '...\n']) 
    return n * phrases
```

Try with and without my proposal changes.